### PR TITLE
fix: resolve four PR #39 post-review follow-up issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,3 +119,51 @@ Output:
 
 Next steps:
 - If you would like, we can automatically apply PATCH/MINOR updates and run tests. Major updates will be listed for manual review because they might introduce breaking changes.
+
+## Running Tests
+
+### Standard run (PowerShell / bash / WSL)
+
+```shell
+mvn test
+```
+
+### Disable Spring Boot Docker Compose during a full test run
+
+**PowerShell / bash:**
+```shell
+mvn test -Dspring.docker.compose.enabled=false
+```
+
+**Windows CMD:** wrap the `-D` argument in double quotes so `=` is not misinterpreted by the batch wrapper:
+```cmd
+mvn test "-Dspring.docker.compose.enabled=false"
+```
+
+> Note: `ApplicationContextTest` already declares `spring.docker.compose.enabled=false` via
+> `@SpringBootTest(properties = {...})`, so the flag is only needed when running the full suite
+> and you want to suppress Docker Compose for all other tests as well.
+
+### Running `ApplicationContextTest` with Testcontainers on Windows
+
+Testcontainers needs access to the Docker socket. Two ways to provide it:
+
+**Option A — IDE (zero configuration)**
+
+`src/test/resources/testcontainers.properties` is already committed and points at the
+Docker Desktop named pipe. Just make sure Docker Desktop is running and run the test normally
+from your IDE.
+
+**Option B — Maven command line with the Windows profile**
+
+```shell
+mvn test -Pwindows-docker-desktop
+```
+
+The `windows-docker-desktop` Maven profile sets `DOCKER_HOST` to the Docker Desktop named pipe
+(`npipe:////./pipe/dockerDesktopLinuxEngine`) via the Surefire `environmentVariables` block, so
+Testcontainers picks it up automatically.
+
+> If you see `[WARNING] The requested profile "windows-docker-desktop" could not be activated …`
+> make sure you are on the `feat/spring-boot-4-upgrade` branch (or any branch that includes the
+> profiles section of `pom.xml`). The profile does not exist in older branches.

--- a/pom.xml
+++ b/pom.xml
@@ -240,9 +240,9 @@
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-surefire-plugin</artifactId>
                         <configuration>
-                            <systemPropertyVariables>
-                                <DOCKER_HOST>tcp://localhost:2375</DOCKER_HOST>
-                            </systemPropertyVariables>
+                            <environmentVariables>
+                                <DOCKER_HOST>npipe:////./pipe/dockerDesktopLinuxEngine</DOCKER_HOST>
+                            </environmentVariables>
                         </configuration>
                     </plugin>
                 </plugins>

--- a/src/test/resources/testcontainers.properties
+++ b/src/test/resources/testcontainers.properties
@@ -1,0 +1,1 @@
+docker.host=npipe:////./pipe/dockerDesktopLinuxEngine


### PR DESCRIPTION
## Summary

Follow-up to PR #39 (`feat/spring-boot-4-upgrade`) addressing the four issues reported in the post-merge comment.

- **Issue 1 (dependency tree in logs):** `structure-maven-plugin` was already removed from this branch in commit `c5eb797`. The tree only appears on `main` (not yet updated). No code change needed; confirmed with `mvn compile` — zero plugin output.
- **Issue 2 (`-Dspring.docker.compose.enabled=false` fails on CMD):** Added a "Running Tests" section to README documenting the Windows CMD-safe quoting (`mvn test "-Dspring.docker.compose.enabled=false"`) and clarifying that `ApplicationContextTest` already injects this flag via `@SpringBootTest(properties = {...})`.
- **Issue 3 (`ApplicationContextTest` cannot run from IDE):** Added `src/test/resources/testcontainers.properties` pointing at the Docker Desktop named pipe (`npipe:////./pipe/dockerDesktopLinuxEngine`). Testcontainers reads this file automatically so no IDE run-configuration changes are needed.
- **Issue 4 (`windows-docker-desktop` profile not found / `DOCKER_HOST` not propagated):** The profile was correctly placed at root `<project>` level, but used `<systemPropertyVariables>` — Testcontainers reads `DOCKER_HOST` via `System.getenv()`, not `System.getProperty()`. Changed to `<environmentVariables>` and updated the Docker host from `tcp://localhost:2375` to the named pipe, which works without enabling the TCP socket in Docker Desktop settings. The "profile not found" warning was a red herring: it occurred because the command was run on the `main` branch, which has no `<profiles>` section.

## Test Plan

- [x] `mvn help:all-profiles | grep windows` — `windows-docker-desktop` profile visible to Maven
- [x] `mvn compile` — no structure/tree output
- [x] `mvn test -Dspring.docker.compose.enabled=false` — 16/16 tests pass, 0 failures
- [ ] Run `ApplicationContextTest` from IDE with Docker Desktop running — should work via `testcontainers.properties`
- [ ] Run `mvn test -Pwindows-docker-desktop` — should pass `DOCKER_HOST` as environment variable to Surefire JVM

🤖 Generated with [Claude Code](https://claude.com/claude-code)